### PR TITLE
use caverealms' local copy of check_attached_node()

### DIFF
--- a/falling_ice.lua
+++ b/falling_ice.lua
@@ -186,7 +186,7 @@ function caverealms:nodeupdate_single(p, delay)
 	end
 
 	if minetest.get_item_group(n.name, "attached_node") ~= 0 then
-		if not check_attached_node(p, n) then
+		if not caverealms:check_attached_node(p, n) then
 			caverealms:drop_attached_node(p)
 			caverealms:nodeupdate(p)
 		end

--- a/nodes.lua
+++ b/nodes.lua
@@ -89,7 +89,7 @@ minetest.register_node("caverealms:hanging_thin_ice", {
 	description = "Thin Ice (hanging)",
 	tiles = {"caverealms_thin_ice.png"},
 	is_ground_content = true,
-	groups = {cracky=3},
+	groups = {cracky=3, not_in_creative_inventory = 1},
 	sounds = default.node_sound_glass_defaults(),
 	use_texture_alpha = true,
 	drawtype = "glasslike",

--- a/nodes.lua
+++ b/nodes.lua
@@ -86,7 +86,7 @@ minetest.register_node("caverealms:thin_ice", {
 
 --alternate version for stalactites
 minetest.register_node("caverealms:hanging_thin_ice", {
-	description = "Thin Ice",
+	description = "Thin Ice (hanging)",
 	tiles = {"caverealms_thin_ice.png"},
 	is_ground_content = true,
 	groups = {cracky=3},


### PR DESCRIPTION
This PR, fixes a crash in falling ice.  Also fixes a duplicate node description, and takes the "hanging" thin ice out of the creative inv.

Also, I notice also that your fork is way behind compared to upstream, but it still works fine .  You ought to consider syncing :stuck_out_tongue_closed_eyes: 